### PR TITLE
Added the ability to set a process pool for the zombie's web view

### DIFF
--- a/Classes/Renderer.swift
+++ b/Classes/Renderer.swift
@@ -41,7 +41,7 @@ internal class Renderer : NSObject {
     private var webView : WKWebView!
     internal static let scrapingCommand = "document.documentElement.outerHTML"
     
-    override init() {
+    init(processPool: WKProcessPool? = nil) {
         super.init()
         let doneLoadingWithoutMediaContentScript = "window.webkit.messageHandlers.doneLoading.postMessage(\(Renderer.scrapingCommand));"
         let doneLoadingUserScript = WKUserScript(source: doneLoadingWithoutMediaContentScript, injectionTime: .AtDocumentEnd, forMainFrameOnly: true)
@@ -56,6 +56,7 @@ internal class Renderer : NSObject {
         contentController.addUserScript(getElementUserScript)
 
         let config = WKWebViewConfiguration()
+        config.processPool = processPool ?? WKProcessPool()
         config.userContentController = contentController
         
         /// Note: The WKWebView behaves very unreliable when rendering offscreen

--- a/Classes/WKZombie.swift
+++ b/Classes/WKZombie.swift
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 import Foundation
+import WebKit
 
 public class WKZombie : NSObject {
     
@@ -47,13 +48,13 @@ public class WKZombie : NSObject {
      
      - returns: A WKZombie instance.
      */
-    public init(name: String? = "WKZombie") {
+    public init(name: String? = "WKZombie", processPool: WKProcessPool? = nil) {
         super.init()
         self.name = name
-        self.renderer = Renderer()
+        self.renderer = Renderer(processPool: processPool)
         self.fetcher = ContentFetcher()
     }
- 
+    
     //========================================
     // MARK: Response Handling
     //========================================


### PR DESCRIPTION
Setting a specific `WKProcessPool` for the zombie's web view to use allows sharing the same process pool with other webviews, so I can use `WKZombie` to authenticate my user with a website and use the same session/cookies on another web view which is not managed by `WKZombie`.

Let me know if you have any questions or if you need any changes to the PR.