### PR TITLE
Improving how WKWebView is injected into view hierarchy in OS X

### DIFF
--- a/Classes/Renderer.swift
+++ b/Classes/Renderer.swift
@@ -75,8 +75,8 @@ internal class Renderer : NSObject {
                     window.insertSubview(self.webView, atIndex: 0)
                 }
             #elseif os(OSX)
-                let window = NSApplication.sharedApplication().keyWindow!
-                let contentView = window.contentView!
+                guard let window = NSApplication.sharedApplication().keyWindow else { preconditionFailure("missing key window") }
+                guard let contentView = window.contentView else { preconditionFailure("key window is missing content view") }
                 let size = contentView.bounds.size
 
                 self.webView = WKWebView(frame: CGRect(origin: CGPointZero, size: size), configuration: config)

--- a/Classes/Renderer.swift
+++ b/Classes/Renderer.swift
@@ -75,13 +75,14 @@ internal class Renderer : NSObject {
                     window.insertSubview(self.webView, atIndex: 0)
                 }
             #elseif os(OSX)
-                if let size = NSScreen.mainScreen()?.frame.size {
-                    self.webView = WKWebView(frame: CGRect(origin: CGPointZero, size: size), configuration: config)
-                    if let window = NSApplication.sharedApplication().keyWindow {
-                        self.webView.alphaValue = 0.01
-                        window.contentView?.addSubview(self.webView)
-                    }
-                }
+                let window = NSApplication.sharedApplication().keyWindow!
+                let contentView = window.contentView!
+                let size = contentView.bounds.size
+
+                self.webView = WKWebView(frame: CGRect(origin: CGPointZero, size: size), configuration: config)
+                self.webView.alphaValue = 0.01
+
+                contentView.addSubview(self.webView)
             #endif
         }
     }

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ __Note:__ You will need CocoaPods 1.0 beta4 or higher.
 A WKZombie instance equates to a web session, which can be created using the following line:
 
 ```ruby
-let browser = WKZombie(name: "Demo")
+self.browser = WKZombie(name: "Demo")
 ```
+
+Be sure to keep `browser` in a stored property for the time of being used.
 
 #### Chaining Actions
 


### PR DESCRIPTION
If `keyWindow` or `contentView` isn't set yet, we want a crash, not a silent failure. This crash will indicate a programmer error.