### PR TITLE
Bugfixes + Improvements for 'Real-Life' Usage

### DIFF
--- a/Classes/Definitions.swift
+++ b/Classes/Definitions.swift
@@ -190,15 +190,11 @@ public func ===<T>(a: Action<T>, completion: Result<T> -> Void) {
 }
 
 internal func parseResponse(response: Response) -> Result<NSData> {
-    guard let data = response.data else {
-        return .Error(.NetworkRequestFailure)
-    }
-    
     let successRange = 200..<300
     if !successRange.contains(response.statusCode) {
         return .Error(.NetworkRequestFailure)
     }
-    return Result(nil, data)
+    return Result(nil, response.data ?? NSData())
 }
 
 internal func resultFromOptional<A>(optional: A?, error: ActionError) -> Result<A> {

--- a/Classes/Definitions.swift
+++ b/Classes/Definitions.swift
@@ -125,7 +125,7 @@ internal struct Response {
     }
 }
 
-infix operator >>> { associativity left precedence 150 }
+infix operator >>> { associativity left precedence 170 }
 internal func >>><A, B>(a: Result<A>, f: A -> Result<B>) -> Result<B> {
     switch a {
     case let .Success(x):   return f(x)
@@ -147,7 +147,7 @@ public func >>><T, U>(a: Action<T>, f: T -> Action<U>) -> Action<U> {
 }
 
 /**
- This Operator equates to the andThen() method with the exception, that the result of the left-hand 
+ This Operator equates to the andThen() method with the exception, that the result of the left-hand
  side Action will be ignored and not passed as paramter to the right-hand side Action.
  
  - parameter a: An Action.
@@ -158,6 +158,29 @@ public func >>><T, U>(a: Action<T>, f: T -> Action<U>) -> Action<U> {
 public func >>><T, U>(a: Action<T>, b: Action<U>) -> Action<U> {
     let f : (T -> Action<U>) = { _ in b }
     return a.andThen(f)
+}
+
+
+/**
+ This Operator equates to the andThen() method with the exception, that the result of the left-hand
+ side Action will be ignored and not passed as paramter to the right-hand side Action.
+
+ *Note:* This a workaround to remove the brackets of functions without any parameters (e.g. **inspect()**)
+ to provide a consistent API.
+ */
+public func >>><T, U: Page>(a: Action<T>, f: () -> Action<U>) -> Action<U> {
+    return a >>> f()
+}
+
+/**
+ This Operator equates to the andThen() method. Here, the left-hand side Action will be started
+ and the result is used as parameter for the right-hand side Action.
+ 
+ *Note:* This a workaround to remove the brackets of functions without any parameters (e.g. **inspect()**)
+ to provide a consistent API.
+ */
+public func >>><T:Page, U>(a: () -> Action<T>, f: T -> Action<U>) -> Action<U> {
+    return a() >>> f
 }
 
 /**

--- a/Classes/Functions.swift
+++ b/Classes/Functions.swift
@@ -183,7 +183,11 @@ public func get<T: HTMLElement>(by searchType: SearchType<T>) -> (page: HTMLPage
  The returned WKZombie Action will execute a JavaScript string __using the shared WKZombie instance__.
  - seealso: _execute()_ function in _WKZombie_ class for more info.
  */
-public func execute(script: JavaScript) -> (page: HTMLPage) -> Action<JavaScriptResult> {
+public func execute() -> (script: JavaScript) -> Action<JavaScriptResult> {
+    return WKZombie.sharedInstance.execute()
+}
+
+public func execute<T: HTMLPage>(script: JavaScript) -> (page: T) -> Action<JavaScriptResult> {
     return WKZombie.sharedInstance.execute(script)
 }
 

--- a/Classes/Functions.swift
+++ b/Classes/Functions.swift
@@ -121,7 +121,7 @@ public func press<T: Page>(then postAction: PostAction) -> (button : HTMLButton)
 //========================================
 
 /**
- Swaps the current page context with the context of an embedded iFrame.
+ The returned WKZombie Action will swap the current page context with the context of an embedded iframe.
  - seealso: _swap()_ function in _WKZombie_ class for more info.
  */
 public func swap<T: Page>(iframe : HTMLFrame) -> Action<T> {
@@ -129,7 +129,7 @@ public func swap<T: Page>(iframe : HTMLFrame) -> Action<T> {
 }
 
 /**
- Swaps the current page context with the context of an embedded iFrame.
+ The returned WKZombie Action will swap the current page context with the context of an embedded iframe.
  - seealso: _swap()_ function in _WKZombie_ class for more info.
  */
 public func swap<T: Page>(then postAction: PostAction) -> (iframe : HTMLFrame) -> Action<T> {

--- a/Classes/Functions.swift
+++ b/Classes/Functions.swift
@@ -183,8 +183,8 @@ public func get<T: HTMLElement>(by searchType: SearchType<T>) -> (page: HTMLPage
  The returned WKZombie Action will execute a JavaScript string __using the shared WKZombie instance__.
  - seealso: _execute()_ function in _WKZombie_ class for more info.
  */
-public func execute() -> (script: JavaScript) -> Action<JavaScriptResult> {
-    return WKZombie.sharedInstance.execute()
+public func execute(script: JavaScript) -> Action<JavaScriptResult> {
+    return WKZombie.sharedInstance.execute(script)
 }
 
 /**
@@ -308,7 +308,7 @@ public func decode<T : JSONDecodable>(array: JSONParsable) -> Action<[T]> {
     infix operator >>* { associativity left precedence 150 }
     public func >>*<T, U>(a: Action<T>, f: T -> Action<U>) -> Action<U> {
         assert(WKZombie.Static.instance != nil, "The >>* operator can only be used with the WKZombie shared instance.")
-        return a >>> snap() >>> f
+        return a >>> snap >>> f
     }
     
     /**
@@ -317,8 +317,8 @@ public func decode<T : JSONDecodable>(array: JSONParsable) -> Action<[T]> {
      __The shared WKZombie instance will be used__.
      - seealso: _snap()_ function in _WKZombie_ class for more info.
      */
-    public func snap<T>() -> (element: T) -> Action<T> {
-        return WKZombie.sharedInstance.snap()
+    public func snap<T>(element: T) -> Action<T> {
+        return WKZombie.sharedInstance.snap(element)
     }
     
 #endif

--- a/Classes/Functions.swift
+++ b/Classes/Functions.swift
@@ -116,6 +116,25 @@ public func press<T: Page>(then postAction: PostAction) -> (button : HTMLButton)
     return WKZombie.sharedInstance.press(then: postAction)
 }
 
+//========================================
+// MARK: Swap Page Context
+//========================================
+
+/**
+ Swaps the current page context with the context of an embedded iFrame.
+ - seealso: _swap()_ function in _WKZombie_ class for more info.
+ */
+public func swap<T: Page>(iframe : HTMLFrame) -> Action<T> {
+    return WKZombie.sharedInstance.swap(iframe)
+}
+
+/**
+ Swaps the current page context with the context of an embedded iFrame.
+ - seealso: _swap()_ function in _WKZombie_ class for more info.
+ */
+public func swap<T: Page>(then postAction: PostAction) -> (iframe : HTMLFrame) -> Action<T> {
+    return WKZombie.sharedInstance.swap(then: postAction)
+}
 
 //========================================
 // MARK: DOM Modification Methods

--- a/Classes/Functions.swift
+++ b/Classes/Functions.swift
@@ -187,6 +187,10 @@ public func execute() -> (script: JavaScript) -> Action<JavaScriptResult> {
     return WKZombie.sharedInstance.execute()
 }
 
+/**
+ The returned WKZombie Action will execute a JavaScript string __using the shared WKZombie instance__.
+ - seealso: _execute()_ function in _WKZombie_ class for more info.
+ */
 public func execute<T: HTMLPage>(script: JavaScript) -> (page: T) -> Action<JavaScriptResult> {
     return WKZombie.sharedInstance.execute(script)
 }
@@ -220,6 +224,13 @@ public func map<T, A>(f: T -> A) -> (object: T) -> Action<A> {
     return WKZombie.sharedInstance.map(f)
 }
 
+/**
+ This function transforms an object into another object using the specified closure.
+ - seealso: _map()_ function in _WKZombie_ class for more info.
+ */
+public func map<T, A>(f: T -> A) -> (object: T) -> A {
+    return WKZombie.sharedInstance.map(f)
+}
 
 //========================================
 // MARK: Advanced Actions

--- a/Classes/Functions.swift
+++ b/Classes/Functions.swift
@@ -305,7 +305,7 @@ public func decode<T : JSONDecodable>(array: JSONParsable) -> Action<[T]> {
      This is a convenience operator for the _snap()_ command. It is equal to the __>>>__ operator with the difference
      that a snapshot will be taken after the left Action has been finished.
      */
-    infix operator >>* { associativity left precedence 150 }
+    infix operator >>* { associativity left precedence 170 }
     public func >>*<T, U>(a: Action<T>, f: T -> Action<U>) -> Action<U> {
         assert(WKZombie.Static.instance != nil, "The >>* operator can only be used with the WKZombie shared instance.")
         return a >>> snap >>> f

--- a/Classes/Functions.swift
+++ b/Classes/Functions.swift
@@ -306,8 +306,28 @@ public func decode<T : JSONDecodable>(array: JSONParsable) -> Action<[T]> {
      that a snapshot will be taken after the left Action has been finished.
      */
     infix operator >>* { associativity left precedence 170 }
-    public func >>*<T, U>(a: Action<T>, f: T -> Action<U>) -> Action<U> {
+    
+    private func assertIfNotSharedInstance() {
         assert(WKZombie.Static.instance != nil, "The >>* operator can only be used with the WKZombie shared instance.")
+    }
+    
+    public func >>*<T, U>(a: Action<T>, f: T -> Action<U>) -> Action<U> {
+        assertIfNotSharedInstance()
+        return a >>> snap >>> f
+    }
+    
+    public func >>*<T, U>(a: Action<T>, b: Action<U>) -> Action<U> {
+        assertIfNotSharedInstance()
+        return a >>> snap >>> b
+    }
+    
+    public func >>*<T, U: Page>(a: Action<T>, f: () -> Action<U>) -> Action<U> {
+        assertIfNotSharedInstance()
+        return a >>> snap >>> f
+    }
+    
+    public func >>*<T:Page, U>(a: () -> Action<T>, f: T -> Action<U>) -> Action<U> {
+        assertIfNotSharedInstance()
         return a >>> snap >>> f
     }
     

--- a/Classes/HTML/HTMLButton.swift
+++ b/Classes/HTML/HTMLButton.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// HTML Button class, which represents the <button> element in the DOM.
-public class HTMLButton : HTMLClickable {
+public class HTMLButton : HTMLRedirectable {
 
     //========================================
     // MARK: Overrides

--- a/Classes/HTML/HTMLForm.swift
+++ b/Classes/HTML/HTMLForm.swift
@@ -41,6 +41,11 @@ public class HTMLForm : HTMLElement {
         return objectForKey("name")
     }
     
+    /// Returns the value for the id attribute.
+    public var id : String? {
+        return objectForKey("id")
+    }
+    
     /// Returns the value for the action attribute.
     public var action : String? {
         return objectForKey("action")
@@ -64,6 +69,8 @@ public class HTMLForm : HTMLElement {
     internal func actionScript() -> String? {
         if let name = name {
             return "document.\(name).submit();"
+        } else if let id = id {
+            return "document.getElementById('\(id)').submit();"
         }
         return nil
     }

--- a/Classes/HTML/HTMLFrame.swift
+++ b/Classes/HTML/HTMLFrame.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-/// HTML iFrame Class, which represents the <iframe> element in the DOM.
+/// HTML iframe Class, which represents the <iframe> element in the DOM.
 public class HTMLFrame : HTMLRedirectable {
     
     /// Returns the value of the src attribute of the iframe.

--- a/Classes/HTML/HTMLFrame.swift
+++ b/Classes/HTML/HTMLFrame.swift
@@ -1,7 +1,7 @@
 //
-// HTMLImage.swift
+// HTMLFrame.swift
 //
-// Copyright (c) 2015 Mathias Koehnke (http://www.mathiaskoehnke.com)
+// Copyright (c) 2016 Mathias Koehnke (http://www.mathiaskoehnke.com)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,29 +23,21 @@
 
 import Foundation
 
-/// HTML Image class, which represents the <img> element in the DOM.
-public class HTMLImage : HTMLElement, HTMLFetchable {
+/// HTML iFrame Class, which represents the <iframe> element in the DOM.
+public class HTMLFrame : HTMLRedirectable {
     
-    //========================================
-    // MARK: Initializer
-    //========================================
-    
-    public required init?(element: AnyObject, XPathQuery: String? = nil) {
-        super.init(element: element, XPathQuery: XPathQuery)
-    }
-    
-    /// Returns the value of the src attribute of the image.
+    /// Returns the value of the src attribute of the iframe.
     public var source : String? {
         return objectForKey("src")
     }
-
+    
     //========================================
-    // MARK: HTMLFetchable Protocol
+    // MARK: Redirect Script
     //========================================
     
-    public var fetchURL : NSURL? {
+    internal override func actionScript() -> String? {
         if let source = source {
-            return NSURL(string: source)
+            return "window.top.location.href='\(source)';"
         }
         return nil
     }
@@ -55,6 +47,6 @@ public class HTMLImage : HTMLElement, HTMLFetchable {
     //========================================
     
     internal override class func createXPathQuery(parameters: String) -> String {
-        return "//img\(parameters)"
+        return "//iframe\(parameters)"
     }
 }

--- a/Classes/HTML/HTMLLink.swift
+++ b/Classes/HTML/HTMLLink.swift
@@ -24,7 +24,7 @@
 import Foundation
 
 /// HTML Link class, which represents the <a> element in the DOM.
-public class HTMLLink : HTMLClickable, HTMLFetchable {
+public class HTMLLink : HTMLRedirectable, HTMLFetchable {
     
     /// Returns the value of the href attribute of the link.
     public var href : String? {

--- a/Classes/HTML/HTMLRedirectable.swift
+++ b/Classes/HTML/HTMLRedirectable.swift
@@ -1,5 +1,5 @@
 //
-//  HTMLClickable.swift
+//  HTMLRedirectable.swift
 //  WKZombieDemo
 //
 //  Created by Mathias Köhnke on 06/04/16.
@@ -8,8 +8,8 @@
 
 import Foundation
 
-/// Base class for clickable HTML elements (e.g. HTMLLink, HTMLButton).
-public class HTMLClickable : HTMLElement {
+/// Base class for redirectable HTML elements (e.g. HTMLLink, HTMLButton).
+public class HTMLRedirectable : HTMLElement {
 
     //========================================
     // MARK: Initializer
@@ -20,7 +20,7 @@ public class HTMLClickable : HTMLElement {
     }
     
     //========================================
-    // MARK: Link Click Script
+    // MARK: Link Redirectable Script
     //========================================
     
     internal func actionScript() -> String? {

--- a/Classes/Parser.swift
+++ b/Classes/Parser.swift
@@ -104,7 +104,7 @@ public class HTMLParserElement : NSObject {
     }
     
     public func objectForKey(key: String) -> String? {
-        return element?.objectForKey(key) as String?
+        return element?.objectForKey(key.lowercaseString) as String?
     }
     
     public func childrenWithTagName<T: HTMLElement>(tagName: String) -> [T]? {

--- a/Classes/WKZombie.swift
+++ b/Classes/WKZombie.swift
@@ -95,6 +95,25 @@ public class WKZombie : NSObject {
         let responseResult: Result<Response> = Result(errorDomain, Response(data: data, statusCode: statusCode))
         return responseResult >>> parseResponse
     }
+    
+    //========================================
+    // MARK: HTMLRedirectable Handling
+    //========================================
+    
+    private func redirect<T: Page, U: HTMLRedirectable>(then postAction: PostAction = .None) -> (redirectable : U) -> Action<T> {
+        return { (redirectable: U) -> Action<T> in
+            return Action() { [unowned self] completion in
+                if let script = redirectable.actionScript() {
+                    self._renderer.executeScript(script, willLoadPage: true, postAction: postAction, completionHandler: { result, response, error in
+                        let data = self._handleResponse(result as? NSData, response: response, error: error)
+                        completion(data >>> decodeResult(response?.URL))
+                    })
+                } else {
+                    completion(Result.Error(.NetworkRequestFailure))
+                }
+            }
+        }
+    }
 }
 
 
@@ -217,7 +236,7 @@ extension WKZombie {
      */
     public func click<T: Page>(then postAction: PostAction) -> (link : HTMLLink) -> Action<T> {
         return { [unowned self] (link: HTMLLink) -> Action<T> in
-            return self._touch(then: postAction)(clickable: link)
+            return self.redirect(then: postAction)(redirectable: link)
         }
     }
     
@@ -242,23 +261,38 @@ extension WKZombie {
      */
     public func press<T: Page>(then postAction: PostAction) -> (button : HTMLButton) -> Action<T> {
         return { [unowned self] (button: HTMLButton) -> Action<T> in
-            return self._touch(then: postAction)(clickable: button)
+            return self.redirect(then: postAction)(redirectable: button)
         }
     }
+}
+
+//========================================
+// MARK: Swap Page Context
+//========================================
+
+extension WKZombie {
+    /**
+     Swaps the current page context with the context of an embedded iFrame.
+     
+     - parameter iframe: The HTMLFrame (iFrame).
+     
+     - returns: The WKZombie Action.
+     */
+    public func swap<T: Page>(iframe : HTMLFrame) -> Action<T> {
+        return swap(then: .None)(iframe: iframe)
+    }
     
-    // Private
-    private func _touch<T: Page, U: HTMLClickable>(then postAction: PostAction = .None) -> (clickable : U) -> Action<T> {
-        return { (clickable: U) -> Action<T> in
-            return Action() { [unowned self] completion in
-                if let script = clickable.actionScript() {
-                    self._renderer.executeScript(script, willLoadPage: true, postAction: postAction, completionHandler: { result, response, error in
-                        let data = self._handleResponse(result as? NSData, response: response, error: error)
-                        completion(data >>> decodeResult(response?.URL))
-                    })
-                } else {
-                    completion(Result.Error(.NetworkRequestFailure))
-                }
-            }
+    /**
+     Swaps the current page context with the context of an iFrame.
+     
+     - parameter postAction: An wait/validation action that will be performed after the page has reloaded.
+     - parameter iframe: The HTMLFrame (iFrame).
+     
+     - returns: The WKZombie Action.
+     */
+    public func swap<T: Page>(then postAction: PostAction) -> (iframe : HTMLFrame) -> Action<T> {
+        return { [unowned self] (iframe: HTMLFrame) -> Action<T> in
+            return self.redirect(then: postAction)(redirectable: iframe)
         }
     }
 }

--- a/Classes/WKZombie.swift
+++ b/Classes/WKZombie.swift
@@ -272,7 +272,7 @@ extension WKZombie {
 
 extension WKZombie {
     /**
-     Swaps the current page context with the context of an embedded iFrame.
+     The returned WKZombie Action will swap the current page context with the context of an embedded iframe.
      
      - parameter iframe: The HTMLFrame (iFrame).
      
@@ -283,7 +283,7 @@ extension WKZombie {
     }
     
     /**
-     Swaps the current page context with the context of an iFrame.
+     The returned WKZombie Action will swap the current page context with the context of an embedded iFrame.
      
      - parameter postAction: An wait/validation action that will be performed after the page has reloaded.
      - parameter iframe: The HTMLFrame (iFrame).

--- a/Classes/WKZombie.swift
+++ b/Classes/WKZombie.swift
@@ -382,8 +382,8 @@ extension WKZombie {
      
      - returns: The WKZombie Action.
      */
-    public func execute(script: JavaScript) -> (page: HTMLPage) -> Action<JavaScriptResult> {
-        return { (page: HTMLPage) -> Action<JavaScriptResult> in
+    public func execute() -> (script: JavaScript) -> Action<JavaScriptResult> {
+        return { (script: JavaScript) -> Action<JavaScriptResult> in
             return Action() { [unowned self] completion in
                 self._renderer.executeScript(script, completionHandler: { result, response, error in
                     let data = self._handleResponse(result as? NSData, response: response, error: error)
@@ -392,6 +392,20 @@ extension WKZombie {
                     completion(output)
                 })
             }
+        }
+    }
+    
+    /**
+     The returned WKZombie Action will execute a JavaScript string.
+     
+     - parameter script: A JavaScript string.
+     - parameter page: A HTML page.
+     
+     - returns: The WKZombie Action.
+     */
+    public func execute<T: HTMLPage>(script: JavaScript) -> (page : T) -> Action<JavaScriptResult> {
+        return { [unowned self] (page : T) -> Action<JavaScriptResult> in
+            return self.execute()(script: script)
         }
     }
 }
@@ -439,13 +453,27 @@ extension WKZombie {
      The returned WKZombie Action will transform a HTMLElement into another HTMLElement using the specified function.
      
      - parameter f: The function that takes a certain HTMLElement as parameter and transforms it into another HTMLElement.
-     - parameter element: A HTML element.
+     - parameter object: A HTML element.
      
      - returns: The WKZombie Action.
      */
     public func map<T, A>(f: T -> A) -> (object: T) -> Action<A> {
         return { (object: T) -> Action<A> in
             return Action(result: resultFromOptional(f(object), error: .NotFound))
+        }
+    }
+    
+    /**
+     This function transforms an object into another object using the specified closure.
+     
+     - parameter f: The closure that takes an object as parameter and transforms it into another object.
+     - parameter object: An object.
+     
+     - returns: The transformed object.
+     */
+    public func map<T, A>(f: T -> A) -> (object: T) -> A {
+        return { (object: T) -> A in
+            return f(object)
         }
     }
 }

--- a/Classes/WKZombie.swift
+++ b/Classes/WKZombie.swift
@@ -382,16 +382,14 @@ extension WKZombie {
      
      - returns: The WKZombie Action.
      */
-    public func execute() -> (script: JavaScript) -> Action<JavaScriptResult> {
-        return { (script: JavaScript) -> Action<JavaScriptResult> in
-            return Action() { [unowned self] completion in
-                self._renderer.executeScript(script, completionHandler: { result, response, error in
-                    let data = self._handleResponse(result as? NSData, response: response, error: error)
-                    let output = data >>> decodeString
-                    Logger.log("Script Result".uppercaseString + "\n\(output)\n")
-                    completion(output)
-                })
-            }
+    public func execute(script: JavaScript) -> Action<JavaScriptResult> {
+        return Action() { [unowned self] completion in
+            self._renderer.executeScript(script, completionHandler: { result, response, error in
+                let data = self._handleResponse(result as? NSData, response: response, error: error)
+                let output = data >>> decodeString
+                Logger.log("Script Result".uppercaseString + "\n\(output)\n")
+                completion(output)
+            })
         }
     }
     
@@ -405,7 +403,7 @@ extension WKZombie {
      */
     public func execute<T: HTMLPage>(script: JavaScript) -> (page : T) -> Action<JavaScriptResult> {
         return { [unowned self] (page : T) -> Action<JavaScriptResult> in
-            return self.execute()(script: script)
+            return self.execute(script)
         }
     }
 }
@@ -577,19 +575,17 @@ extension WKZombie {
      
      - returns: A snapshot class.
      */
-    public func snap<T>() -> (element: T) -> Action<T> {
-        return { (element: T) -> Action<T> in
-            return Action<T>(operation: { [unowned self] completion in
-                delay(DefaultSnapshotDelay, completion: {
-                    if let snapshotHandler = self.snapshotHandler, snapshot = self._renderer.snapshot() {
-                        snapshotHandler(snapshot)
-                        completion(Result.Success(element))
-                    } else {
-                        completion(Result.Error(.SnapshotFailure))
-                    }
-                })
+    public func snap<T>(element: T) -> Action<T> {
+        return Action<T>(operation: { [unowned self] completion in
+            delay(DefaultSnapshotDelay, completion: {
+                if let snapshotHandler = self.snapshotHandler, snapshot = self._renderer.snapshot() {
+                    snapshotHandler(snapshot)
+                    completion(Result.Success(element))
+                } else {
+                    completion(Result.Error(.SnapshotFailure))
+                }
             })
-        }
+        })
     }
 }
     

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The following snippet demonstrates how you would use WKZombie to **collect all P
 >>* get(by: .Contains("href", "/account/"))
 >>> click(then: .Wait(2.5))
 >>* getAll(by: .Contains("class", "row-"))
-=== handleResult
+=== myOutput
 ```
 
 In order to output or process the collected data, one can either use a closure or implement a custom function taking the result as parameter:

--- a/README.md
+++ b/README.md
@@ -206,10 +206,11 @@ func setAttribute<T: HTMLElement>(key: String, value: String?) -> (element: T) -
 
 ### Execute JavaScript
 
-The returned WKZombie Action will execute a JavaScript string.
+The returned WKZombie Actions will execute a JavaScript string.
 
 ```ruby
 func execute(script: JavaScript) -> (page: HTMLPage) -> Action<JavaScriptResult>
+func execute(script: JavaScript) -> Action<JavaScriptResult>
 ```
 
 For example, the following example shows how retrieve the title of the currently loaded website using the *execute()* method:
@@ -218,10 +219,22 @@ For example, the following example shows how retrieve the title of the currently
     browser.inspect()
 >>> browser.execute("document.title")
 === myOutput
+
+func myOutput(result: JavaScriptResult?) {
+  // handle result
+}
 ```
 
+The following code shows another way to execute JavaScript, that is e.g. value of an attribute:
 ```ruby
-func myOutput(result: JavaScriptResult?) {
+    browser.open(url)
+>>> browser.get(by: .Id("div"))
+>>> browser.map { $0.objectForKey("onClick")! }
+>>> browser.execute
+>>> browser.inspect()
+=== myOutput
+
+func myOutput(result: HTMLPage?) {
   // handle result
 }
 ```
@@ -253,6 +266,11 @@ The returned WKZombie Action will transform a WKZombie object into another objec
 func map<T, A>(f: T -> A) -> (element: T) -> Action<A>
 ```
 
+This function transforms an object into another object using the specified function *f*.
+```ruby
+func map<T, A>(f: T -> A) -> (object: T) -> A
+```
+
 ## Taking Snapshots
 
 Taking snapshots is **available for iOS**. First, a *snapshotHandler* must be registered, that will be called each time a snapshot has been taken:
@@ -272,10 +290,10 @@ Secondly, adding the `>>*` operator will trigger the snapshot event:
 ```
 **Note: This operator only works with the WKZombie shared instance.**
 
-Alternatively, one can use the *snap()* command:
+Alternatively, one can use the *snap* command:
 ```ruby
     browser.open(url)
->>> browser.snap()
+>>> browser.snap
 >>> browser.get(by: .Id("element"))
 === myOutput
 ```
@@ -321,7 +339,7 @@ The following Operators can be applied to *Actions*, which makes chained *Action
 Operator    | iOS | OSX | Description
 :----------:|:---:|:---:| ---------------
 `>>>`       | x   | x   | This Operator equates to the *andThen()* method. Here, the left-hand side *Action* will be started and the result is used as parameter for the right-hand side *Action*. **Note:** If the right-hand side *Action* doesn't take a parameter, the result of the left-hand side *Action* will be ignored and not passed.
-`>>*`       | x   |     | This is a convenience operator for the _snap()_ command. It is equal to the `>>>` operator with the difference that a snapshot will be taken after the left Action has been finished. **Note: This operator throws an assert if used with any other than the shared instance.**
+`>>*`       | x   |     | This is a convenience operator for the _snap_ command. It is equal to the `>>>` operator with the difference that a snapshot will be taken after the left Action has been finished. **Note: This operator throws an assert if used with any other than the shared instance.**
 `===`       | x   | x   | This Operator starts the left-hand side *Action* and passes the result as **Optional** to the function on the right-hand side.
 
 ## Advanced Actions
@@ -338,6 +356,26 @@ func batch<T, U>(f: T -> Action<U>) -> (elements: [T]) -> Action<[U]>
 The returned WKZombie Action will execute the specified action (with the result of the previous action execution as input parameter) until a certain condition is met. Afterwards, it will return the collected action results.
 ```ruby
 func collect<T>(f: T -> Action<T>, until: T -> Bool) -> (initial: T) -> Action<[T]>
+```
+
+### Swap
+
+**Note:** Due to a XPath limitation, WKZombie can't access elements within an `iframe` directly. The swap function can workaround this issue by switching web contexts.
+
+The returned WKZombie Action will swap the current page context with the context of an embedded `<iframe>`.
+```ruby
+func swap<T: Page>(iframe : HTMLFrame) -> Action<T>
+func swap<T: Page>(then postAction: PostAction) -> (iframe : HTMLFrame) -> Action<T>
+```
+
+The following example shows how to press a button that is embedded in an iframe:
+```ruby
+    browser.open(startURL())
+>>> browser.get(by: .XPathQuery("//iframe[@name='button_frame']"))
+>>> browser.swap
+>>> browser.get(by: .Id("button"))
+>>> browser.press
+=== myOutput
 ```
 
 ## Test / Debug

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ func execute(script: JavaScript) -> Action<JavaScriptResult>
 For example, the following example shows how retrieve the title of the currently loaded website using the *execute()* method:
 
 ```ruby
-    browser.inspect()
+    browser.inspect
 >>> browser.execute("document.title")
 === myOutput
 
@@ -231,7 +231,7 @@ The following code shows another way to execute JavaScript, that is e.g. value o
 >>> browser.get(by: .Id("div"))
 >>> browser.map { $0.objectForKey("onClick")! }
 >>> browser.execute
->>> browser.inspect()
+>>> browser.inspect
 === myOutput
 
 func myOutput(result: HTMLPage?) {

--- a/Tests/Classes/Tests.swift
+++ b/Tests/Classes/Tests.swift
@@ -123,7 +123,7 @@ class Tests: XCTestCase {
             >>> browser.get(by: .Id("onClick_div"))
             >>> browser.map { $0.objectForKey("onClick")! }
             >>> browser.execute
-            >>> browser.inspect()
+            >>> browser.inspect
             >>> browser.execute("document.title")
             === { (result: JavaScriptResult?) in
                 XCTAssertEqual(result, "WKZombie Result Page")
@@ -140,7 +140,7 @@ class Tests: XCTestCase {
             >>> browser.get(by: .Id("href_div"))
             >>> browser.map { "window.location.href='\($0.objectForKey("href")!)'" }
             >>> browser.execute
-            >>> browser.inspect()
+            >>> browser.inspect
             >>> browser.execute("document.title")
             === { (result: JavaScriptResult?) in
                 XCTAssertEqual(result, "WKZombie Result Page")

--- a/Tests/Classes/Tests.swift
+++ b/Tests/Classes/Tests.swift
@@ -55,9 +55,9 @@ class Tests: XCTestCase {
         let expectation = expectationWithDescription("Inspect Done.")
         var originalPage : HTMLPage?
         
-        browser.open(startURL())
+            browser.open(startURL())
         >>> browser.map { originalPage = $0 as HTMLPage }
-        >>> browser.inspect()
+        >>> browser.inspect
         === { (result: HTMLPage?) in
             if let result = result, originalPage = originalPage {
                 XCTAssertEqual(result.data, originalPage.data)
@@ -118,7 +118,7 @@ class Tests: XCTestCase {
     
     func testDivOnClick() {
         let expectation = expectationWithDescription("DIV OnClick Done.")
-        
+    
         browser.open(startURL())
             >>> browser.get(by: .Id("onClick_div"))
             >>> browser.map { $0.objectForKey("onClick")! }

--- a/Tests/Classes/Tests.swift
+++ b/Tests/Classes/Tests.swift
@@ -101,6 +101,40 @@ class Tests: XCTestCase {
         waitForExpectationsWithTimeout(20.0, handler: nil)
     }
     
+    func testDivOnClick() {
+        let expectation = expectationWithDescription("DIV OnClick Done.")
+        
+        browser.open(startURL())
+            >>> browser.get(by: .Id("onClick_div"))
+            >>> browser.map { $0.objectForKey("onClick")! }
+            >>> browser.execute()
+            >>> browser.inspect()
+            >>> browser.execute("document.title")
+            === { (result: JavaScriptResult?) in
+                XCTAssertEqual(result, "WKZombie Result Page")
+                expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(20.0, handler: nil)
+    }
+    
+    func testDivHref() {
+        let expectation = expectationWithDescription("DIV Href Done.")
+        
+        browser.open(startURL())
+            >>> browser.get(by: .Id("href_div"))
+            >>> browser.map { "window.location.href='\($0.objectForKey("href")!)'" }
+            >>> browser.execute()
+            >>> browser.inspect()
+            >>> browser.execute("document.title")
+            === { (result: JavaScriptResult?) in
+                XCTAssertEqual(result, "WKZombie Result Page")
+                expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(20.0, handler: nil)
+    }
+    
     func testUserAgent() {
         let expectation = expectationWithDescription("UserAgent Test Done.")
         browser.userAgent = "WKZombie"

--- a/Tests/Classes/Tests.swift
+++ b/Tests/Classes/Tests.swift
@@ -107,7 +107,7 @@ class Tests: XCTestCase {
         browser.open(startURL())
             >>> browser.get(by: .Id("onClick_div"))
             >>> browser.map { $0.objectForKey("onClick")! }
-            >>> browser.execute()
+            >>> browser.execute
             >>> browser.inspect()
             >>> browser.execute("document.title")
             === { (result: JavaScriptResult?) in
@@ -124,7 +124,7 @@ class Tests: XCTestCase {
         browser.open(startURL())
             >>> browser.get(by: .Id("href_div"))
             >>> browser.map { "window.location.href='\($0.objectForKey("href")!)'" }
-            >>> browser.execute()
+            >>> browser.execute
             >>> browser.inspect()
             >>> browser.execute("document.title")
             === { (result: JavaScriptResult?) in
@@ -160,10 +160,10 @@ class Tests: XCTestCase {
         }
         
         browser.open(startURL())
+        >>> browser.snap
         >>> browser.get(by: .Name("button"))
-        >>> browser.snap()
         >>> browser.press
-        >>> browser.snap()
+        >>> browser.snap
         === { (result: HTMLPage?) in
             XCTAssertEqual(snapshots.count, 2)
             expectation.fulfill()

--- a/Tests/Classes/Tests.swift
+++ b/Tests/Classes/Tests.swift
@@ -86,6 +86,21 @@ class Tests: XCTestCase {
         waitForExpectationsWithTimeout(20.0, handler: nil)
     }
     
+    func testFormSubmit() {
+        let expectation = expectationWithDescription("Form Submit Done.")
+        
+        browser.open(startURL())
+            >>> browser.get(by: .Id("test_form"))
+            >>> browser.submit
+            >>> browser.execute("document.title")
+            === { (result: JavaScriptResult?) in
+                XCTAssertEqual(result, "WKZombie Result Page")
+                expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(20.0, handler: nil)
+    }
+    
     func testUserAgent() {
         let expectation = expectationWithDescription("UserAgent Test Done.")
         browser.userAgent = "WKZombie"

--- a/Tests/Classes/Tests.swift
+++ b/Tests/Classes/Tests.swift
@@ -101,6 +101,21 @@ class Tests: XCTestCase {
         waitForExpectationsWithTimeout(20.0, handler: nil)
     }
     
+    func testFormWithXPathQuerySubmit() {
+        let expectation = expectationWithDescription("Form XPathQuery Submit Done.")
+        
+        browser.open(startURL())
+            >>> browser.get(by: .XPathQuery("//form[1]"))
+            >>> browser.submit
+            >>> browser.execute("document.title")
+            === { (result: JavaScriptResult?) in
+                XCTAssertEqual(result, "WKZombie Result Page")
+                expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(20.0, handler: nil)
+    }
+    
     func testDivOnClick() {
         let expectation = expectationWithDescription("DIV OnClick Done.")
         

--- a/Tests/Classes/Tests.swift
+++ b/Tests/Classes/Tests.swift
@@ -123,6 +123,23 @@ class Tests: XCTestCase {
         waitForExpectationsWithTimeout(20.0, handler: nil)
     }
     
+    func testSwap() {
+        let expectation = expectationWithDescription("iFrame Button Test Done.")
+        
+        browser.open(startURL())
+        >>> browser.get(by: .XPathQuery("//iframe[@name='button_frame']"))
+        >>> browser.swap
+        >>> browser.get(by: .XPathQuery("//button[@name='button2']"))
+        >>> browser.press
+        >>> browser.execute("document.title")
+        === { (result: JavaScriptResult?) in
+            XCTAssertEqual(result, "WKZombie Result Page")
+            expectation.fulfill()
+        }
+        
+        waitForExpectationsWithTimeout(20.0, handler: nil)
+    }
+    
     //========================================
     // MARK: Helper Methods
     //========================================

--- a/Tests/Classes/Tests.swift
+++ b/Tests/Classes/Tests.swift
@@ -188,7 +188,7 @@ class Tests: XCTestCase {
     }
     
     func testSwap() {
-        let expectation = expectationWithDescription("iFrame Button Test Done.")
+        let expectation = expectationWithDescription("iframe Button Test Done.")
         
         browser.open(startURL())
         >>> browser.get(by: .XPathQuery("//iframe[@name='button_frame']"))

--- a/Tests/Resources/HTMLEmbeddedPage.html
+++ b/Tests/Resources/HTMLEmbeddedPage.html
@@ -1,0 +1,6 @@
+<html>
+    <head></head>
+    <body>
+        <button type="button" name="button2" onClick="window.top.location.href='HTMLResultPage.html'">No, Click Me!</button>
+    </body>
+</html>

--- a/Tests/Resources/HTMLTestPage.html
+++ b/Tests/Resources/HTMLTestPage.html
@@ -4,5 +4,6 @@
     </head>
     <body>
     <button type="button" name="button" onClick="location.href='HTMLResultPage.html'">Click Me!</button>
+    <iframe src="HTMLEmbeddedPage.html" name="button_frame"></iframe>
     </body>
 </html>

--- a/Tests/Resources/HTMLTestPage.html
+++ b/Tests/Resources/HTMLTestPage.html
@@ -5,5 +5,10 @@
     <body>
     <button type="button" name="button" onClick="location.href='HTMLResultPage.html'">Click Me!</button>
     <iframe src="HTMLEmbeddedPage.html" name="button_frame"></iframe>
+    <form id="test_form" method="get" action="HTMLResultPage.html">
+        <input type="checkbox" name="option" value="option1"/>Option 1<br/>
+        <input type="checkbox" name="option" value="option2" checked="checked"/>Option 2<br/>
+        <input type="submit" value="Submit"/>
+    </form>
     </body>
 </html>

--- a/Tests/Resources/HTMLTestPage.html
+++ b/Tests/Resources/HTMLTestPage.html
@@ -1,14 +1,25 @@
 <html>
     <head>
         <title>WKZombie Test Page</title>
+        <script>
+            function testFunction() {
+                window.location.href="HTMLResultPage.html";
+            }
+        </script>
     </head>
     <body>
     <button type="button" name="button" onClick="location.href='HTMLResultPage.html'">Click Me!</button>
+    
     <iframe src="HTMLEmbeddedPage.html" name="button_frame"></iframe>
+    
     <form id="test_form" method="get" action="HTMLResultPage.html">
         <input type="checkbox" name="option" value="option1"/>Option 1<br/>
         <input type="checkbox" name="option" value="option2" checked="checked"/>Option 2<br/>
         <input type="submit" value="Submit"/>
     </form>
+    
+    <div id="onClick_div" onClick="testFunction()"></div>
+    <div id="href_div" href="HTMLResultPage.html"></div>
+    
     </body>
 </html>

--- a/WKZombie.xcodeproj/project.pbxproj
+++ b/WKZombie.xcodeproj/project.pbxproj
@@ -8,11 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		BF09CBF31CE278B0009B97D2 /* Snapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF09CBF21CE278B0009B97D2 /* Snapshot.swift */; };
+		BF18445C1CFE12D6002C31B5 /* HTMLEmbeddedPage.html in Resources */ = {isa = PBXBuildFile; fileRef = BF18445B1CFE12D6002C31B5 /* HTMLEmbeddedPage.html */; };
+		BF18445E1CFE1A5C002C31B5 /* HTMLFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF18445D1CFE1A5C002C31B5 /* HTMLFrame.swift */; };
+		BF18445F1CFE1A5C002C31B5 /* HTMLFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF18445D1CFE1A5C002C31B5 /* HTMLFrame.swift */; };
 		BF1F91231CB6A52300A58A7F /* ContentFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F910F1CB6A52300A58A7F /* ContentFetcher.swift */; };
 		BF1F91241CB6A52300A58A7F /* Definitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91101CB6A52300A58A7F /* Definitions.swift */; };
 		BF1F91251CB6A52300A58A7F /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91111CB6A52300A58A7F /* Error.swift */; };
 		BF1F91261CB6A52300A58A7F /* HTMLButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91131CB6A52300A58A7F /* HTMLButton.swift */; };
-		BF1F91271CB6A52300A58A7F /* HTMLClickable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91141CB6A52300A58A7F /* HTMLClickable.swift */; };
+		BF1F91271CB6A52300A58A7F /* HTMLRedirectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91141CB6A52300A58A7F /* HTMLRedirectable.swift */; };
 		BF1F91281CB6A52300A58A7F /* HTMLElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91151CB6A52300A58A7F /* HTMLElement.swift */; };
 		BF1F91291CB6A52300A58A7F /* HTMLFetchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91161CB6A52300A58A7F /* HTMLFetchable.swift */; };
 		BF1F912A1CB6A52300A58A7F /* HTMLForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91171CB6A52300A58A7F /* HTMLForm.swift */; };
@@ -39,7 +42,7 @@
 		BFD2E8B41CB7D0830085B499 /* hpple.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFD2E8B31CB7D0830085B499 /* hpple.framework */; };
 		BFD2E8B61CB7D0A80085B499 /* hpple.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFD2E8B51CB7D0A80085B499 /* hpple.framework */; };
 		BFD2E8ED1CB7F2BB0085B499 /* HTMLButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91131CB6A52300A58A7F /* HTMLButton.swift */; };
-		BFD2E8EE1CB7F2BB0085B499 /* HTMLClickable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91141CB6A52300A58A7F /* HTMLClickable.swift */; };
+		BFD2E8EE1CB7F2BB0085B499 /* HTMLRedirectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91141CB6A52300A58A7F /* HTMLRedirectable.swift */; };
 		BFD2E8EF1CB7F2BB0085B499 /* HTMLElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91151CB6A52300A58A7F /* HTMLElement.swift */; };
 		BFD2E8F01CB7F2BB0085B499 /* HTMLFetchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91161CB6A52300A58A7F /* HTMLFetchable.swift */; };
 		BFD2E8F11CB7F2BB0085B499 /* HTMLForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1F91171CB6A52300A58A7F /* HTMLForm.swift */; };
@@ -79,11 +82,13 @@
 
 /* Begin PBXFileReference section */
 		BF09CBF21CE278B0009B97D2 /* Snapshot.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Snapshot.swift; sourceTree = "<group>"; };
+		BF18445B1CFE12D6002C31B5 /* HTMLEmbeddedPage.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = HTMLEmbeddedPage.html; sourceTree = "<group>"; };
+		BF18445D1CFE1A5C002C31B5 /* HTMLFrame.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLFrame.swift; sourceTree = "<group>"; };
 		BF1F910F1CB6A52300A58A7F /* ContentFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContentFetcher.swift; sourceTree = "<group>"; };
 		BF1F91101CB6A52300A58A7F /* Definitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Definitions.swift; sourceTree = "<group>"; };
 		BF1F91111CB6A52300A58A7F /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		BF1F91131CB6A52300A58A7F /* HTMLButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLButton.swift; sourceTree = "<group>"; };
-		BF1F91141CB6A52300A58A7F /* HTMLClickable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLClickable.swift; sourceTree = "<group>"; };
+		BF1F91141CB6A52300A58A7F /* HTMLRedirectable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLRedirectable.swift; sourceTree = "<group>"; };
 		BF1F91151CB6A52300A58A7F /* HTMLElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLElement.swift; sourceTree = "<group>"; };
 		BF1F91161CB6A52300A58A7F /* HTMLFetchable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLFetchable.swift; sourceTree = "<group>"; };
 		BF1F91171CB6A52300A58A7F /* HTMLForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTMLForm.swift; sourceTree = "<group>"; };
@@ -179,7 +184,7 @@
 			isa = PBXGroup;
 			children = (
 				BF1F91131CB6A52300A58A7F /* HTMLButton.swift */,
-				BF1F91141CB6A52300A58A7F /* HTMLClickable.swift */,
+				BF1F91141CB6A52300A58A7F /* HTMLRedirectable.swift */,
 				BF1F91151CB6A52300A58A7F /* HTMLElement.swift */,
 				BF1F91161CB6A52300A58A7F /* HTMLFetchable.swift */,
 				BF1F91171CB6A52300A58A7F /* HTMLForm.swift */,
@@ -187,6 +192,7 @@
 				BF1F91191CB6A52300A58A7F /* HTMLLink.swift */,
 				BF1F911A1CB6A52300A58A7F /* HTMLPage.swift */,
 				BF1F911B1CB6A52300A58A7F /* HTMLTable.swift */,
+				BF18445D1CFE1A5C002C31B5 /* HTMLFrame.swift */,
 			);
 			path = HTML;
 			sourceTree = "<group>";
@@ -233,8 +239,9 @@
 		BF1F916E1CB6AFAF00A58A7F /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				BF1F916F1CB6AFAF00A58A7F /* HTMLResultPage.html */,
 				BF1F91701CB6AFAF00A58A7F /* HTMLTestPage.html */,
+				BF1F916F1CB6AFAF00A58A7F /* HTMLResultPage.html */,
+				BF18445B1CFE12D6002C31B5 /* HTMLEmbeddedPage.html */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -428,6 +435,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF1F91771CB6B03E00A58A7F /* HTMLTestPage.html in Resources */,
+				BF18445C1CFE12D6002C31B5 /* HTMLEmbeddedPage.html in Resources */,
 				BF1F91761CB6B03B00A58A7F /* HTMLResultPage.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -488,7 +496,8 @@
 				BFD2E8EF1CB7F2BB0085B499 /* HTMLElement.swift in Sources */,
 				BFD2E8FD1CB7F2C00085B499 /* WKZombie.swift in Sources */,
 				BFD2E8FB1CB7F2C00085B499 /* Renderer.swift in Sources */,
-				BFD2E8EE1CB7F2BB0085B499 /* HTMLClickable.swift in Sources */,
+				BF18445F1CFE1A5C002C31B5 /* HTMLFrame.swift in Sources */,
+				BFD2E8EE1CB7F2BB0085B499 /* HTMLRedirectable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -517,7 +526,8 @@
 				BF1F912E1CB6A52300A58A7F /* HTMLTable.swift in Sources */,
 				BF1F912F1CB6A52300A58A7F /* JSONPage.swift in Sources */,
 				BF1F912C1CB6A52300A58A7F /* HTMLLink.swift in Sources */,
-				BF1F91271CB6A52300A58A7F /* HTMLClickable.swift in Sources */,
+				BF1F91271CB6A52300A58A7F /* HTMLRedirectable.swift in Sources */,
+				BF18445E1CFE1A5C002C31B5 /* HTMLFrame.swift in Sources */,
 				BF1F912D1CB6A52300A58A7F /* HTMLPage.swift in Sources */,
 				BF1F91261CB6A52300A58A7F /* HTMLButton.swift in Sources */,
 				BF1F91241CB6A52300A58A7F /* Definitions.swift in Sources */,
@@ -811,6 +821,7 @@
 				BF455DAC1CEFBF99006D97D0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		BFAECCA61CB69C0200C87F3B /* Build configuration list for PBXProject "WKZombie" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
#### Description
- Due to a XPath limitation, WKZombie can't access elements within an iFrame directly. In order to work around this issue, I've added the functionality to swap the current page with an embedded iframe page.
- Bugfix for submitting a form using the ID tag
- Added additonal execute() / map() functions for easier JavaScript usage
-  **Breaking Change:** Removed brackets from execute() and snap() function

#### TODO's
- [x] Updated README / Documentation
- [x] Unit Tests

