### PR TITLE
Added showNetworkActivity property

### DIFF
--- a/Example/Example iOS/LoginViewController.swift
+++ b/Example/Example iOS/LoginViewController.swift
@@ -44,10 +44,16 @@ class LoginViewController : UIViewController {
     
     @IBAction func loginButtonTouched(_ button: UIButton) {
         guard let user = nameTextField.text, let password = passwordTextField.text else { return }
-        button.isEnabled = false
+        setUserInterfaceEnabled(enabled: false)
         snapshots.removeAll()
         activityIndicator.startAnimating()
         getProvisioningProfiles(url, user: user, password: password)
+    }
+    
+    private func setUserInterfaceEnabled(enabled: Bool) {
+        nameTextField.isEnabled = enabled
+        passwordTextField.isEnabled = enabled
+        loginButton.isEnabled = enabled
     }
     
     //========================================
@@ -85,12 +91,18 @@ class LoginViewController : UIViewController {
     }
     
     func handleError(_ error: ActionError) {
-        print("Error loading page: \(error)")
-        loginButton.isEnabled = true
-        activityIndicator.stopAnimating()
-        
-        dump()
         clearCache()
+        dump()
+        
+        inspect >>> execute("document.title") === { [weak self] (result: JavaScriptResult?) in
+            let title = result ?? "<Unknown>"
+            let alert = UIAlertController(title: "Error On Page:", message: "\"\(title)\"", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "Ok", style: .cancel, handler: nil))
+            self?.present(alert, animated: true) {
+                self?.setUserInterfaceEnabled(enabled: true)
+                self?.activityIndicator.stopAnimating()
+            }
+        }
     }
     
     //========================================

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - hpple (0.2.0)
-  - WKZombie (1.0.5):
+  - WKZombie (1.0.7):
     - hpple (= 0.2.0)
 
 DEPENDENCIES:
@@ -8,11 +8,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WKZombie:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   hpple: 3b765f96fc2cd56ad1a49aef6f7be5cb2aa64b57
-  WKZombie: 3729a149e35bbec9df8f3bdf5d7d3b0416edc3b2
+  WKZombie: 0d1369decbcf6e58cd267ac937aef1bf38e5b99e
 
 PODFILE CHECKSUM: d530690e373e4c270897769971faa34622df5672
 

--- a/README.md
+++ b/README.md
@@ -488,6 +488,15 @@ This value is 'true' by default. If set 'false', the loading progress will finis
 browser.loadMediaContent = false
 ```
 
+### Show Network Activity
+
+If set to ``true``, it will show the network activity indicator in the status bar. The default is ``true``.
+
+```ruby
+browser.showNetworkActivity = true
+```
+
+
 ## HTML Elements
 
 When using WKZombie, the following classes are involved when interacting with websites:

--- a/Sources/WKZombie/Error.swift
+++ b/Sources/WKZombie/Error.swift
@@ -44,7 +44,7 @@ extension ActionError: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case .networkRequestFailure: return "Network Request Failure"
-        case .notFound: return "Not Found"
+        case .notFound: return "Element Not Found"
         case .parsingFailure: return "Parsing Failure"
         case .transformFailure: return "Transform Failure"
         case .snapshotFailure: return "Snapshot Failure"

--- a/Sources/WKZombie/Renderer.swift
+++ b/Sources/WKZombie/Renderer.swift
@@ -43,6 +43,8 @@ internal class Renderer : NSObject {
     
     var timeoutInSeconds : TimeInterval = 30.0
     
+    var showNetworkActivity : Bool = true
+    
     internal static let scrapingCommand = "document.documentElement.outerHTML"
     
     internal var authenticationHandler : AuthenticationHandler?
@@ -165,6 +167,7 @@ internal class Renderer : NSObject {
     fileprivate func operationWithRequestBlock(_ requestBlock: @escaping (_ operation: RenderOperation) -> Void, postAction: PostAction = .none, completionHandler: RenderCompletion?) -> Operation {
         let operation = RenderOperation(webView: webView, timeoutInSeconds: timeoutInSeconds)
         operation.loadMediaContent = loadMediaContent
+        operation.showNetworkActivity = showNetworkActivity
         operation.postAction = postAction
         operation.completionBlock = { [weak operation] in
             completionHandler?(operation?.result, operation?.response, operation?.error)

--- a/Sources/WKZombie/WKZombie.swift
+++ b/Sources/WKZombie/WKZombie.swift
@@ -93,6 +93,16 @@ open class WKZombie : NSObject {
     #if os(iOS)
     /// Snapshot Handler
     open var snapshotHandler : SnapshotHandler?
+    
+    /// If 'true', shows the network activity indicator in the status bar. The default is 'true'.
+    open var showNetworkActivity : Bool {
+        get {
+            return self._renderer.showNetworkActivity
+        }
+        set {
+            self._renderer.showNetworkActivity = newValue
+        }
+    }
     #endif
     
     /**

--- a/WKZombie.podspec
+++ b/WKZombie.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "WKZombie"
-  s.version      = "1.0.7"
+  s.version      = "1.0.8"
   s.summary      = "WKZombie is a Swift library for iOS/OSX to browse websites without the need of User Interface or API."
 
   s.description  = <<-DESC


### PR DESCRIPTION
This pull requests adds the ``showNetworkActivity`` property, that can be used to enable/disable the network activity indicator in the status bar. Furthermore, there's better error handling in the iOS sample.