### PR TITLE
Fixed Name collision issue with keyword "Result" when using WKZombie in the same project with Alamofire in it.

### DIFF
--- a/Sources/WKZombie/HTMLFetchable.swift
+++ b/Sources/WKZombie/HTMLFetchable.swift
@@ -67,7 +67,7 @@ extension HTMLFetchable {
 
 public protocol HTMLFetchableContent {
     associatedtype ContentType
-    static func instanceFromData(_ data: Data) -> Result<ContentType>
+    static func instanceFromData(_ data: Data) -> WKZombie.Result<ContentType>
 }
 
 //==========================================
@@ -78,18 +78,18 @@ public protocol HTMLFetchableContent {
     import UIKit
     extension UIImage : HTMLFetchableContent {
         public typealias ContentType = UIImage
-        public static func instanceFromData(_ data: Data) -> Result<ContentType> {
+        public static func instanceFromData(_ data: Data) -> WKZombie.Result<ContentType> {
             if let image = UIImage(data: data) {
-                return Result.success(image)
+                return WKZombie.Result.success(image)
             }
-            return Result.error(.transformFailure)
+            return WKZombie.Result.error(.transformFailure)
         }
     }
 #elseif os(OSX)
     import Cocoa
     extension NSImage : HTMLFetchableContent {
         public typealias ContentType = NSImage
-        public static func instanceFromData(_ data: Data) -> Result<ContentType> {
+        public static func instanceFromData(_ data: Data) -> WKZombie.Result<ContentType> {
             if let image = NSImage(data: data) {
                 return Result.success(image)
             }
@@ -100,7 +100,7 @@ public protocol HTMLFetchableContent {
 
 extension Data : HTMLFetchableContent {
     public typealias ContentType = Data
-    public static func instanceFromData(_ data: Data) -> Result<ContentType> {
-        return Result.success(data)
+    public static func instanceFromData(_ data: Data) -> WKZombie.Result<ContentType> {
+        return WKZombie.Result.success(data)
     }
 }

--- a/Sources/WKZombie/HTMLPage.swift
+++ b/Sources/WKZombie/HTMLPage.swift
@@ -49,11 +49,11 @@ public class HTMLPage : HTMLParser, Page {
     // MARK: Find Elements
     //========================================
     
-    public func findElements<T: HTMLElement>(_ searchType: SearchType<T>) -> Result<[T]> {
+    public func findElements<T: HTMLElement>(_ searchType: SearchType<T>) -> WKZombie.Result<[T]> {
         let query = searchType.xPathQuery()
         if let parsedObjects = searchWithXPathQuery(query) , parsedObjects.count > 0 {
             return resultFromOptional(parsedObjects.flatMap { T(element: $0, XPathQuery: query) }, error: .notFound)
         }
-        return Result.error(.notFound)
+        return WKZombie.Result.error(.notFound)
     }
 }

--- a/Sources/WKZombie/Parser.swift
+++ b/Sources/WKZombie/Parser.swift
@@ -137,7 +137,7 @@ public class JSONParser : Parser {
     
     required public init(data: Data, url: URL? = nil) {
         super.init(data: data, url: url)
-        let result : Result<JSON> = parseJSON(data)
+        let result : WKZombie.Result<JSON> = parseJSON(data)
         switch result {
         case .success(let json): self.json = json
         case .error: Logger.log("Error parsing JSON!")

--- a/Sources/WKZombie/WKZombie.swift
+++ b/Sources/WKZombie/WKZombie.swift
@@ -30,7 +30,23 @@ public typealias SnapshotHandler = (Snapshot) -> Void
 public class WKZombie {
     
     private static var __once: () = {  Static.instance = WKZombie() }()
+  
+  
+
+  /// Result
+  public enum Result<T> {
+    case success(T)
+    case error(ActionError)
     
+    init(_ error: ActionError?, _ value: T) {
+      if let err = error {
+        self = .error(err)
+      } else {
+        self = .success(value)
+      }
+    }
+  }
+  
     /// A shared instance of `Manager`, used by top-level WKZombie methods,
     /// and suitable for multiple web sessions.
     public class var sharedInstance: WKZombie {


### PR DESCRIPTION
This resolves an issue where there is a name collision of keyword "Result" when using WKZombie in the same project with Alamofire in it.

ERROR: "Result' is ambiguous for type lookup in this context" with Alamofire in the same project