### PR TITLE
Migrated to Swift 5.2 and added protocol fix for XCode 12

### DIFF
--- a/Sources/WKZombie/HTMLPage.swift
+++ b/Sources/WKZombie/HTMLPage.swift
@@ -52,7 +52,7 @@ public class HTMLPage : HTMLParser, Page {
     public func findElements<T>(_ searchType: SearchType<T>) -> Result<[T]> {
         let query = searchType.xPathQuery()
         if let parsedObjects = searchWithXPathQuery(query) , parsedObjects.count > 0 {
-            return resultFromOptional(parsedObjects.flatMap { T(element: $0, XPathQuery: query) }, error: .notFound)
+            return resultFromOptional(parsedObjects.compactMap { T(element: $0, XPathQuery: query) }, error: .notFound)
         }
         return Result.error(.notFound)
     }

--- a/Sources/WKZombie/Parser.swift
+++ b/Sources/WKZombie/Parser.swift
@@ -75,7 +75,7 @@ public class HTMLParser : Parser {
 }
 
 /// A HTML Parser Element class, which wraps the functionality of the TFHppleElement class.
-public class HTMLParserElement : CustomStringConvertible {
+public class HTMLParserElement : CustomStringConvertible, Initializable {
     fileprivate var element : TFHppleElement?
     public internal(set) var XPathQuery : String?
     
@@ -109,11 +109,11 @@ public class HTMLParserElement : CustomStringConvertible {
     }
     
     public func childrenWithTagName<T: HTMLElement>(_ tagName: String) -> [T]? {
-        return element?.children(withTagName: tagName).flatMap { T(element: $0 as AnyObject) }
+        return element?.children(withTagName: tagName).compactMap { T(element: $0 as AnyObject) }
     }
     
     public func children<T: HTMLElement>() -> [T]? {
-        return element?.children.flatMap { T(element:$0 as AnyObject) }
+        return element?.children.compactMap { T(element:$0 as AnyObject) }
     }
     
     public func hasChildren() -> Bool {
@@ -153,5 +153,7 @@ public class JSONParser : Parser {
     }
 }
 
-
+protocol Initializable {
+    init?(element: AnyObject, XPathQuery : String?)
+}
 

--- a/Sources/WKZombie/RenderOperation.swift
+++ b/Sources/WKZombie/RenderOperation.swift
@@ -113,7 +113,7 @@ internal class RenderOperation : Operation {
     func wait(_ condition: () -> Bool) {
         let updateInterval : TimeInterval = 0.1
         var loopUntil = Date(timeIntervalSinceNow: updateInterval)
-        while condition() == false && RunLoop.current.run(mode: RunLoopMode.defaultRunLoopMode, before: loopUntil) {
+        while condition() == false && RunLoop.current.run(mode: RunLoop.Mode.default, before: loopUntil) {
             loopUntil = Date(timeIntervalSinceNow: updateInterval)
             Logger.log(".", lineBreak: false)
         }
@@ -149,7 +149,7 @@ internal class RenderOperation : Operation {
     fileprivate func startTimeout() {
         stopRunLoop = false
         timeout = Timer(timeInterval: timeoutInSeconds, target: self, selector: #selector(RenderOperation.cancel), userInfo: nil, repeats: false)
-        RunLoop.current.add(timeout!, forMode: RunLoopMode.defaultRunLoopMode)
+        RunLoop.current.add(timeout!, forMode: RunLoop.Mode.default)
     }
     
     fileprivate func stopTimeout() {

--- a/Sources/WKZombie/Renderer.swift
+++ b/Sources/WKZombie/Renderer.swift
@@ -224,7 +224,7 @@ extension Renderer {
         let snapshot = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
 
-        if let data = UIImagePNGRepresentation(snapshot!) {
+        if let data = snapshot!.pngData() {
             return Snapshot(data: data, page: webView.url)
         }
         return nil

--- a/WKZombie.podspec
+++ b/WKZombie.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "WKZombie"
-  s.version      = "1.1.1"
+  s.version      = "1.1.2"
   s.summary      = "WKZombie is a Swift library for iOS/OSX to browse websites without the need of User Interface or API."
 
   s.description  = <<-DESC
@@ -15,8 +15,8 @@ Pod::Spec.new do |s|
 
   s.author       = "Mathias Köhnke"
 
-  s.ios.deployment_target = '10.3'
-  s.osx.deployment_target = '10.12'
+  s.ios.deployment_target = '13.3'
+  s.osx.deployment_target = '10.14.2'
 
   s.source       = { :git => "https://github.com/mkoehnke/WKZombie.git", :tag => s.version.to_s }
 
@@ -27,5 +27,5 @@ Pod::Spec.new do |s|
 
   s.dependency 'hpple', '0.2.0' 
 
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.2' }
 end


### PR DESCRIPTION
Some minor updates to fix for Xcode 12 (the current version won't build as it complains about type T not having an init method in Parser.swift - adding a simple Initializable protocol with the required init method fixes it).
And some updates to bring the code from Swift 4 to Swift 5.2 and remove the constant warnings to migrate it.